### PR TITLE
Update for rethinkdb 1.13.1

### DIFF
--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -11,7 +11,7 @@ keywords:
   - database
   - json
 packages:
-  - rethinkdb@1.13
+  - rethinkdb@1.13.1
 script: |
   source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
   wget -O- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
@@ -23,6 +23,6 @@ env:
   WERCKER_RETHINKDB_PORT: 28015
   WERCKER_RETHINKDB_HOST: $$HOST$$
   WERCKER_RETHINKDB_URL: $$HOST$$:28015
-  WERCKER_RETHINKDB_VERSION: "1.13"
+  WERCKER_RETHINKDB_VERSION: "1.13.1"
   RETHINKDB_URL: $$HOST$$:28015
 


### PR DESCRIPTION
I didn't touch the version number (leaving that up to you!) but it would be nice to get this updated, specifically I'm using `r.table('foo').getAll('does-not-exist').nth(0).default(null)` quite often, which does not work on 1.13.0 but does on 1.13.1.
